### PR TITLE
JWT handling in the front-end side

### DIFF
--- a/Receiptly/receiptly-front/src/App.js
+++ b/Receiptly/receiptly-front/src/App.js
@@ -7,19 +7,22 @@ import './App.css'
 import client from "./GraphQL/Client";
 import { ApolloProvider } from "@apollo/client";
 import { SignUpIn } from "./Pages/SignUpIn";
+import { AuthContextProvider } from "./context/AuthContext";
 
 function App() {
   return (
     <ApolloProvider client={client}>
       <div className="App">
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/history" element={<History />} />
-          <Route path="/yourProducts" element={<Products />} />
-          <Route path="/currentRecepits" element={<CurrentRecepits />} />
-          <Route path="/signUp" element={<SignUpIn />} />
-          <Route path="/signIn" element={<SignUpIn login />} />
-        </Routes>
+        <AuthContextProvider>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/history" element={<History />} />
+            <Route path="/yourProducts" element={<Products />} />
+            <Route path="/currentRecepits" element={<CurrentRecepits />} />
+            <Route path="/signUp" element={<SignUpIn />} />
+            <Route path="/signIn" element={<SignUpIn login />} />
+          </Routes>
+        </AuthContextProvider>
       </div>
     </ApolloProvider>
   );

--- a/Receiptly/receiptly-front/src/Components/Sign/SignIn/SignIn.jsx
+++ b/Receiptly/receiptly-front/src/Components/Sign/SignIn/SignIn.jsx
@@ -1,16 +1,18 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { Button } from '../../Button/Button';
 import { TextInput } from '../../TextInput/TextInput';
 import styles from '../Sign.module.css';
 import {LOGIN} from '../../../GraphQL/Auth'
 import { useMutation } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
+import {AuthContext} from '../../../context/AuthContext'
 
 
 const SignIn = () => {
 
     const [user, setUser] = useState({ username: '', password: '' });
     const [tokenAuth, {loading, data, error}] = useMutation(LOGIN);
+    const {setRefreshToken} = useContext(AuthContext)
 
     const inputOnChange = (e) => {
         setUser({ ...user, [e.target.name]: e.target.value });
@@ -31,10 +33,14 @@ const SignIn = () => {
             })
 
             const data = result.data.tokenAuth
+            /* console.log(data) */
 
             if(data.success){
                 const {token} = data.token
+                const {token: refreshToken} = data.refreshToken
+                /* console.log("access token is", token) */
                 localStorage.setItem('Access', token);
+                setRefreshToken(refreshToken)
                 alert("Successfully logged in")
                 navigate("/")
             }

--- a/Receiptly/receiptly-front/src/GraphQL/Auth.js
+++ b/Receiptly/receiptly-front/src/GraphQL/Auth.js
@@ -9,6 +9,9 @@ export const LOGIN = gql`
                 token
             }
             errors
+            refreshToken{
+                token
+            }
         }
     }
 
@@ -27,4 +30,17 @@ export const Register = gql`
             }
         }
 
+`
+
+export const REFRESH_TOKEN = gql`
+
+        mutation refreshToken($refreshToken: String!, $revokeRefreshToken: Boolean!){
+            refreshToken(refreshToken: $refreshToken, revokeRefreshToken: $revokeRefreshToken){
+                success
+                errors
+                token{
+                    token
+                }
+            }
+        }
 `

--- a/Receiptly/receiptly-front/src/context/AuthContext.js
+++ b/Receiptly/receiptly-front/src/context/AuthContext.js
@@ -1,0 +1,57 @@
+import { createContext, useEffect, useState } from 'react'
+import { useMutation } from '@apollo/client';
+import { REFRESH_TOKEN } from '../GraphQL/Auth';
+
+export const AuthContext = createContext();
+
+export const AuthContextProvider = ({children}) => {
+    /* const [authToken, setAuthToken] = useState(null); */
+    const [refreshToken, setRefreshToken] = useState(null);
+
+    const [refresh, { loading, data, error }] = useMutation(REFRESH_TOKEN);
+    /* console.log("Refresh token from context is ", refreshToken) */
+
+    const updateToken = async () => {
+
+        const result = await refresh({
+            variables: {
+                refreshToken,
+                revokeRefreshToken: false
+            }
+        })
+
+        const data = result.data.refreshToken
+
+        const isSuccessful = data.success
+
+        if(isSuccessful){
+            const {token} = data.token
+            localStorage.setItem("Access", token)
+            /* console.log("New access token is ", token) */
+        }
+
+    }
+
+    useEffect(() => {
+
+        const oneHour = 60 * 60 * 1000;
+
+        const interval = setInterval(() => {
+            if(localStorage.getItem("Access")){
+                updateToken();
+            }else{
+                console.log("Refresh token is not valid")
+                setRefreshToken(null)
+            }
+        }, oneHour)
+
+        return () => clearInterval(interval)
+
+    },[refreshToken])
+
+    return(
+        <AuthContext.Provider value={{refreshToken, setRefreshToken}}>
+            {children}
+        </AuthContext.Provider>
+    )
+}


### PR DESCRIPTION
- Create AuthContext to handle the JWT mechanism.
- Add RefreshToken mutation.
- Implement a mechanism when a user successfully logs in, token management starts, and navigate the user to the home page.